### PR TITLE
Squash toc tree into main index file

### DIFF
--- a/ApplicationDeveloperGuide/index.rst
+++ b/ApplicationDeveloperGuide/index.rst
@@ -1,9 +1,0 @@
-Application Developer Guide
-===========================
-
-.. toctree::
-    :maxdepth: 2
-
-    chapterMicroEJOverview
-    chapterMicroEJClasspath
-    chapterMicroEJTools

--- a/SandboxedAppDevGuide/index.rst
+++ b/SandboxedAppDevGuide/index.rst
@@ -1,9 +1,0 @@
-Sandboxed Application Developer Guide
-=====================================
-
-.. toctree::
-    :maxdepth: 2
-
-    chapterMicroEJGettingStarted
-    chapterApplicationStructure
-    chapterSharedInterface

--- a/StandaloneAppDevGuide/index.rst
+++ b/StandaloneAppDevGuide/index.rst
@@ -1,7 +1,0 @@
-Standalone Application Developer Guide
-======================================
-
-.. toctree::
-    :maxdepth: 2
-
-    chapterMicroEJGettingStarted

--- a/_themes/microej/static/css/microej.css
+++ b/_themes/microej/static/css/microej.css
@@ -355,7 +355,7 @@ code,
 .wy-menu-vertical header,
 .wy-menu-vertical p.caption {
   color: #262a2c;
-  font-size: 120%;
+  font-size: .8rem;
 }
 
 .wy-menu-vertical li.current {

--- a/index.rst
+++ b/index.rst
@@ -3,8 +3,22 @@ MicroEJ
 
 .. toctree::
     :maxdepth: 2
-    :hidden:
+    :caption: Application Developer Guide
 
-    ApplicationDeveloperGuide/index
-    SandboxedAppDevGuide/index
-    StandaloneAppDevGuide/index
+    ApplicationDeveloperGuide/chapterMicroEJOverview
+    ApplicationDeveloperGuide/chapterMicroEJClasspath
+    ApplicationDeveloperGuide/chapterMicroEJTools
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Sandboxed Application Guide
+
+    SandboxedAppDevGuide/chapterMicroEJGettingStarted
+    SandboxedAppDevGuide/chapterApplicationStructure
+    SandboxedAppDevGuide/chapterSharedInterface
+
+.. toctree::
+    :maxdepth: 2
+    :caption: Standalone Application Guide
+
+    StandaloneAppDevGuide/chapterMicroEJGettingStarted


### PR DESCRIPTION
This is an example of squashing all of the subpath index files into one
large index and TOC tree.

Using subpath index files will give a nagivation menu that expands,
using the name of the title in the index files. However, this method
requires that ``index.rst`` and ``**/index.rst`` have some additional
content, or the files will appear mostly empty.

This PR shows how to accomplish this using captioned TOC tree
directives, which will create a similar structure on the navigation, but
will remove one level of nesting. However, ``**/index.rst`` can be
removed and do not need additional content, and ``index.rst`` can have
content, but could also remain a full TOC tree listing.

This is what the navigation looks like using subpath ``index.rst`` files (a subpath index file is shown because the main index file is empty):

![image](https://user-images.githubusercontent.com/1140183/69755340-3f2b2900-1115-11ea-9f6f-f93e30b91197.png)

And this is what the navigation and index page look like with this PR:

![image](https://user-images.githubusercontent.com/1140183/69755272-1a36b600-1115-11ea-8348-2e27ea2d680e.png)
